### PR TITLE
fix specifying numbered connection

### DIFF
--- a/internal/handler/execute_command.go
+++ b/internal/handler/execute_command.go
@@ -350,7 +350,8 @@ func (s *Server) switchConnections(ctx context.Context, params lsp.ExecuteComman
 				break
 			}
 		}
-	} else {
+	}
+	if index <= 0 {
 		index, _ = strconv.Atoi(indexStr)
 	}
 


### PR DESCRIPTION
```
:SqlsSwitchConnection 1
```
Does not work.