### PR TITLE
Fix formatter test setup and ignore condition

### DIFF
--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -137,7 +137,6 @@ func TestFormat(t *testing.T) {
 		LowerCase:        false,
 		IdentifierQuoted: false,
 	}
-	env := &formatEnvironment{}
 	for _, fname := range files {
 		b, err := os.ReadFile(fname)
 		if err != nil {
@@ -147,6 +146,7 @@ func TestFormat(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		env := &formatEnvironment{}
 		formatted := Eval(parsed, env)
 		got := strings.TrimRight(formatted.Render(opts), "\n") + "\n"
 

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -156,7 +156,7 @@ func TestFormat(t *testing.T) {
 		}
 		want := string(b)
 		if got != want {
-			if _, err := os.Stat(fname[:len(fname)-4] + ".ignore"); err != nil {
+			if _, err := os.Stat(fname[:len(fname)-4] + ".ignore"); err == nil {
 				t.Logf("%s:\n"+
 					"    want: %q\n"+
 					"     got: %q\n",


### PR DESCRIPTION
While extending the parser functionality, I encountered some issues with the existing formatter test suite:

1. The `formatter_test.go` was sharing a `formatEnvironment` across test cases. This led to state-related bugs due to shared state between tests. Now, a new `formatEnvironment` is created for each test to ensure independence and prevent errors that could arise from shared state.

2. There was a typo in the `.ignore` file naming (`003.ignroe`), and the ignore condition logic was incorrect. The tests incorrectly reported failures when an `.ignore` file was present and an output mismatch occurred. This has been remedied so that now, presence of an `.ignore` file will result in the output being logged instead of causing a failing test.
