### PR TITLE
Initial support for other schemas

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func serve(c *cli.Context) error {
 		logWriter = io.MultiWriter(os.Stderr)
 	}
 	log.SetOutput(logWriter)
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 
 	// Initialize language server
 	server := handler.NewServer()


### PR DESCRIPTION
As seen in https://github.com/sqls-server/sqls/issues/99 there is lack of support for completion when working with other schemas other than the default schema. So this in the initial effort to fix this issue bringing support for:

* table completion when given the schema
* table description for table in any schema
* column completion when given table in any schema
* column completion for tables in any schema referenced in the join clause

In this change there is also a performance change proposal for the queries that retrieve schema information. In my database (~3k tables, ~25k columns) the sqls server hunged up in the foreign key query for the primary cache, after the change it starts up almost instantly