### PR TITLE
completion support for non default schema

### DIFF
--- a/internal/completer/completer.go
+++ b/internal/completer/completer.go
@@ -411,8 +411,19 @@ func getCompletionTypes(nw *parseutil.NodeWalker) *CompletionContext {
 
 func filterCandidates(candidates []lsp.CompletionItem, lastWord string) []lsp.CompletionItem {
 	filtered := []lsp.CompletionItem{}
+	withBackQuote := strings.HasPrefix(lastWord, "`")
+
 	for _, candidate := range candidates {
-		if strings.HasPrefix(strings.ToUpper(candidate.Label), strings.ToUpper(lastWord)) {
+		label := strings.ToUpper(candidate.Label)
+
+		if !withBackQuote && candidate.Kind != lsp.SnippetCompletion {
+			index := strings.LastIndex(label, ".")	
+			if index != -1 {
+				label = label[index+1:]
+			}
+		}
+
+		if strings.HasPrefix(label, strings.ToUpper(lastWord)) {
 			filtered = append(filtered, candidate)
 		}
 	}

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -19,7 +19,7 @@ func NewDBCacheUpdater(repo DBRepository) *DBCacheGenerator {
 func (u *DBCacheGenerator) GenerateDBCachePrimary(ctx context.Context) (*DBCache, error) {
 	var err error
 	dbCache := &DBCache{}
-	dbCache.defaultSchema, err = u.repo.CurrentSchema(ctx)
+	dbCache.DefaultSchema, err = u.repo.CurrentSchema(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -32,13 +32,13 @@ func (u *DBCacheGenerator) GenerateDBCachePrimary(ctx context.Context) (*DBCache
 		dbCache.Schemas[strings.ToUpper(index)] = element
 	}
 
-	if dbCache.defaultSchema == "" {
+	if dbCache.DefaultSchema == "" {
 		var topKey string
 		for k := range dbCache.Schemas {
 			topKey = k
 			continue
 		}
-		dbCache.defaultSchema = dbCache.Schemas[topKey]
+		dbCache.DefaultSchema = dbCache.Schemas[topKey]
 	}
 	schemaTables, err := u.repo.SchemaTables(ctx)
 	if err != nil {
@@ -49,11 +49,11 @@ func (u *DBCacheGenerator) GenerateDBCachePrimary(ctx context.Context) (*DBCache
 		dbCache.SchemaTables[strings.ToUpper(index)] = element
 	}
 
-	dbCache.ColumnsWithParent, err = u.genColumnCacheCurrent(ctx, dbCache.defaultSchema)
+	dbCache.ColumnsWithParent, err = u.genColumnCacheCurrent(ctx, dbCache.DefaultSchema)
 	if err != nil {
 		return nil, err
 	}
-	dbCache.ForeignKeys, err = u.genForeignKeysCache(ctx, dbCache.defaultSchema)
+	dbCache.ForeignKeys, err = u.genForeignKeysCache(ctx, dbCache.DefaultSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func genColumnMap(columnDescs []*ColumnDesc) map[string][]*ColumnDesc {
 }
 
 type DBCache struct {
-	defaultSchema     string
+	DefaultSchema     string
 	Schemas           map[string]string
 	SchemaTables      map[string][]string
 	ColumnsWithParent map[string][]*ColumnDesc
@@ -156,12 +156,12 @@ func (dc *DBCache) SortedTablesByDBName(dbName string) (tbls []string, ok bool) 
 }
 
 func (dc *DBCache) SortedTables() []string {
-	tbls, _ := dc.SortedTablesByDBName(dc.defaultSchema)
+	tbls, _ := dc.SortedTablesByDBName(dc.DefaultSchema)
 	return tbls
 }
 
 func (dc *DBCache) ColumnDescs(tableName string) (cols []*ColumnDesc, ok bool) {
-	cols, ok = dc.ColumnsWithParent[columnDatabaseKey(dc.defaultSchema, tableName)]
+	cols, ok = dc.ColumnsWithParent[columnDatabaseKey(dc.DefaultSchema, tableName)]
 	return
 }
 
@@ -171,7 +171,7 @@ func (dc *DBCache) ColumnDatabase(dbName, tableName string) (cols []*ColumnDesc,
 }
 
 func (dc *DBCache) Column(tableName, colName string) (*ColumnDesc, bool) {
-	cols, ok := dc.ColumnsWithParent[columnDatabaseKey(dc.defaultSchema, tableName)]
+	cols, ok := dc.ColumnsWithParent[columnDatabaseKey(dc.DefaultSchema, tableName)]
 	if !ok {
 		return nil, false
 	}


### PR DESCRIPTION
As seen in https://github.com/sqls-server/sqls/issues/99 and https://github.com/sqls-server/sqls/issues/121 there is lack of support for completion when working with other schemas/databases other than the default schema/database. So this in the initial effort to fix this issue bringing support for:

* table completion when given the schema
* table description for table in any schema
* column completion when given table in any schema
* column completion for tables in any schema referenced in the join clause

Test were added so that the new features/changes are covered