### PR TITLE
fix: make order of extracTables deterministic

### DIFF
--- a/parser/parseutil/parseutil.go
+++ b/parser/parseutil/parseutil.go
@@ -244,14 +244,15 @@ func extractTables(parsed ast.TokenList, pos token.Pos, stopOnPos bool) ([]*Tabl
 	}
 
 	tableMap := map[string]*TableInfo{}
-	for _, table := range tables {
-		tableMap[table.DatabaseSchema+"\t"+table.Name] = table
-	}
 	cleanTables := []*TableInfo{}
-	for _, table := range tableMap {
-		cleanTables = append(cleanTables, table)
-	}
 
+	for _, table := range tables {
+		tableKey := table.DatabaseSchema+"\t"+table.Name
+		if _, ok := tableMap[tableKey]; !ok {
+			tableMap[tableKey] = table
+			cleanTables = append(cleanTables, table)
+		}
+	}
 	return cleanTables, nil
 }
 


### PR DESCRIPTION
if not some test may fail as the order of the result items can change in accordance to the order that the items in the map are iterated

you can reproduce eventually the problem with:

```
❯ while test $? == 0 ; do go test github.com/sqls-server/sqls/parser/parseutil -count=1 -run TestExtractTable/select_table_references; done
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.003s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.004s
ok      github.com/sqls-server/sqls/parser/parseutil    0.005s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.005s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.005s
ok      github.com/sqls-server/sqls/parser/parseutil    0.005s
ok      github.com/sqls-server/sqls/parser/parseutil    0.005s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.004s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.003s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
ok      github.com/sqls-server/sqls/parser/parseutil    0.006s
--- FAIL: TestExtractTable (0.00s)
    --- FAIL: TestExtractTable/select_table_references (0.00s)
        parseutil_test.go:810: unmatched value:   []*parseutil.TableInfo{
                &{
                        DatabaseSchema:  "",
            -           Name:            "abc",
            +           Name:            "def",
                        Alias:           "",
                        SubQueryColumns: nil,
                },
                &{
                        DatabaseSchema:  "",
            -           Name:            "def",
            +           Name:            "abc",
                        Alias:           "",
                        SubQueryColumns: nil,
                },
              }
FAIL
FAIL    github.com/sqls-server/sqls/parser/parseutil    0.005s
FAIL

```