### PR TITLE
feat(hover): POC for inline hover with rust

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/smacker/go-tree-sitter v0.0.0-20240402012804-99ab967cf9b9 // indirect
 	github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e // indirect
 	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smacker/go-tree-sitter v0.0.0-20240402012804-99ab967cf9b9 h1:5HSGLeLdHwoLEEr794DtHfFD67aF4rPLLQFfbVvEF2w=
+github.com/smacker/go-tree-sitter v0.0.0-20240402012804-99ab967cf9b9/go.mod h1:q99oHDsbP0xRwmn7Vmob8gbSMNyvJ83OauXPSuHQuKE=
 github.com/sourcegraph/jsonrpc2 v0.2.0 h1:KjN/dC4fP6aN9030MZCJs9WQbTOjWHhrtKVpzzSrr/U=
 github.com/sourcegraph/jsonrpc2 v0.2.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -233,6 +235,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/internal/handler/format.go
+++ b/internal/handler/format.go
@@ -25,6 +25,10 @@ func (s *Server) handleTextDocumentFormatting(ctx context.Context, conn *jsonrpc
 		return nil, fmt.Errorf("document not found: %s", params.TextDocument.URI)
 	}
 
+	if f.LanguageID != `sql` {
+		return nil, nil
+	}
+
 	textEdits, err := formatter.Format(f.Text, params, s.getConfig())
 	if err != nil {
 		return nil, err

--- a/internal/handler/hover.go
+++ b/internal/handler/hover.go
@@ -33,7 +33,8 @@ func (s *Server) handleTextDocumentHover(ctx context.Context, conn *jsonrpc2.Con
 		return nil, fmt.Errorf("document not found: %s", params.TextDocument.URI)
 	}
 
-	res, err := hover(f.Text, params, s.worker.Cache())
+	text := cleanInjections(f, params.Position)
+	res, err := hover(text, params, s.worker.Cache())
 	if err != nil {
 		if errors.Is(ErrNoHover, err) {
 			return nil, nil

--- a/internal/handler/injection_test.go
+++ b/internal/handler/injection_test.go
@@ -1,0 +1,21 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/sqls-server/sqls/internal/lsp"
+)
+
+func TestCleanRustInjections(t *testing.T) {
+	file := &File{
+		LanguageID: `rust`,
+		Text:       `fn main() { sqlx::query("select * from users").fetch_all(&mut conn).await; }`,
+	}
+	result := cleanRustInjections(file, lsp.Position{Line: 0, Character: 0})
+
+	expected := `                         select * from users                                `
+
+	if result != expected {
+		t.Errorf("got %s, want %s", result, expected)
+	}
+}

--- a/internal/handler/injections.go
+++ b/internal/handler/injections.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/rust"
+	"github.com/sqls-server/sqls/internal/lsp"
+)
+
+func cleanInjections(file *File, position lsp.Position) string {
+	switch file.LanguageID {
+	case `sql`:
+		return file.Text
+	case `rust`:
+		return cleanRustInjections(file, position)
+
+	default:
+		return file.Text
+	}
+}
+
+func cleanRustInjections(file *File, position lsp.Position) string {
+	result := make([]byte, len(file.Text))
+	for i := range result {
+		if file.Text[i] == '\n' || file.Text[i] == '\r' {
+			result[i] = file.Text[i]
+			continue
+		}
+		result[i] = byte(' ')
+	}
+
+	lang := rust.GetLanguage()
+	tree, err := sitter.ParseCtx(context.Background(), []byte(file.Text), lang)
+	if err != nil {
+		return file.Text
+	}
+
+	// TODO: this would need to be configurable
+	query := `((call_expression
+  function: (scoped_identifier
+    path: ((identifier) @_sqlx
+      (#eq? @_sqlx "sqlx"))
+    name: (identifier) @_query
+    (#eq? @_query "query"))
+  arguments: (arguments
+    ((string_literal)
+       @injection.content))))`
+
+	q, err := sitter.NewQuery([]byte(query), lang)
+	if err != nil {
+		return file.Text
+	}
+	qc := sitter.NewQueryCursor()
+	qc.Exec(q, tree)
+	// Iterate over query results
+	for {
+		m, ok := qc.NextMatch()
+		if !ok {
+			break
+		}
+		// Apply predicates filtering
+		m = qc.FilterPredicates(m, []byte(file.Text))
+		for _, c := range m.Captures {
+			fmt.Println(c.Node.String())
+			fmt.Println(c.Node.Content([]byte(file.Text)))
+			captureName := q.CaptureNameForId(c.Index)
+			if captureName == "injection.content" {
+				// TODO: add a check if the position is inside the injection
+				copy(result[c.Node.StartByte()+1:c.Node.EndByte()-1],
+					file.Text[c.Node.StartByte()+1:c.Node.EndByte()-1])
+			}
+		}
+	}
+	return string(result)
+}


### PR DESCRIPTION
Hello everyone, 

This PR provides a POC for supporting inline SQL in other languages (as described in https://github.com/joe-re/sql-language-server/issues/180).

The implementation is inspired by the tree sitter injections in [nvim-tree-sitter](https://github.com/nvim-treesitter/nvim-treesitter) where you can have syntax highlighting for inline languages.

The idea would be for the community to provide tree-sitter [queries](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries) that define how certain parts of the code should be interpreted as SQL, as I did for rust in the POC.
The LSP can then remove all non-SQL code from a file and process only the SQL text.

The example allows the sqls hover function to be used on the following rust code:
```rust
fn main() {
    sqlx::query("select * FROM tags").fetch_all(&mut conn).await;
}
```
![image](https://github.com/sqls-server/sqls/assets/36446499/2e2a1dec-4268-4e71-ae70-f5dbbf87f049)

With the proposed architecture of using queries, the feature could easily be extended to other languages and their SQL libraries, as tree-sitter already provides parsers for most languages.


Please note that adding tree-sitter as a dependency would require the project to be built using cgo.

Running multiple language servers at the same this is supported (at least for neovim) and it should cause no problem if sqls will just return nothing for all positions that are not inside SQL strings.


What do you think about this idea?

