### PR TITLE
Adapt to lower version of clickhouse

### DIFF
--- a/internal/database/clickhouse.go
+++ b/internal/database/clickhouse.go
@@ -224,31 +224,26 @@ func (db *clickhouseSQLDBRepository) DescribeDatabaseTable(ctx context.Context) 
 	rows, err := db.Conn.QueryContext(
 		ctx,
 		`
-SELECT c.table_schema,
-       c.table_name,
-       c.column_name,
-       c.column_type,
-       CASE c.is_nullable
-         WHEN 1 THEN 'YES'
-         ELSE 'NO'
-       END,
-       CASE cu.constraint_name
-         WHEN 'PRIMARY' THEN 'YES'
-         ELSE 'NO'
-       END,
-       c.column_default,
-       ''
-FROM   information_schema.columns c
-       LEFT JOIN (SELECT icu.table_schema,
-                         icu.table_name,
-                         icu.column_name,
-                         icu.constraint_name
-                  FROM   information_schema.key_column_usage icu
-                  WHERE  icu.constraint_name = 'PRIMARY') cu using (
-       table_schema, table_name, column_name)
-WHERE  ( c.table_schema = currentDatabase()
-          OR c.table_schema = '' )
-       AND c.table_name NOT LIKE '%inner%'
+SELECT 
+    c.database ,
+    c.table ,
+    c.name,
+    c.type ,
+    CASE 
+        WHEN c.type LIKE 'Nullable(%)' THEN 'YES'
+        ELSE 'NO'
+    END,
+    CASE 
+        WHEN c.is_in_primary_key THEN 'YES'
+        ELSE 'NO'
+    END ,
+    c.default_expression,
+    ''
+FROM 
+    system.columns c
+WHERE  ( c.database = currentDatabase()
+          OR c.database = '' )
+       AND c.table NOT LIKE '%inner%'
 `)
 	if err != nil {
 		log.Fatal(err)
@@ -279,31 +274,26 @@ func (db *clickhouseSQLDBRepository) DescribeDatabaseTableBySchema(ctx context.C
 	rows, err := db.Conn.QueryContext(
 		ctx,
 		`
-SELECT c.table_schema,
-       c.table_name,
-       c.column_name,
-       c.column_type,
-       CASE c.is_nullable
-         WHEN 1 THEN 'YES'
-         ELSE 'NO'
-       END,
-       CASE cu.constraint_name
-         WHEN 'PRIMARY' THEN 'YES'
-         ELSE 'NO'
-       END,
-       c.column_default,
-       ''
-FROM   information_schema.columns c
-       LEFT JOIN (SELECT icu.table_schema,
-                         icu.table_name,
-                         icu.column_name,
-                         icu.constraint_name
-                  FROM   information_schema.key_column_usage icu
-                  WHERE  icu.constraint_name = 'PRIMARY') cu using (
-       table_schema, table_name, column_name)
-WHERE  ( c.table_schema = ?
-          OR c.table_schema = '' )
-       AND c.table_name NOT LIKE '%inner%'
+SELECT 
+    c.database ,
+    c.table ,
+    c.name,
+    c.type ,
+    CASE 
+        WHEN c.type LIKE 'Nullable(%)' THEN 'YES'
+        ELSE 'NO'
+    END,
+    CASE 
+        WHEN c.is_in_primary_key THEN 'YES'
+        ELSE 'NO'
+    END ,
+    c.default_expression,
+    ''
+FROM 
+    system.columns c
+WHERE  ( c.database = ?
+          OR c.database = '' )
+       AND c.table NOT LIKE '%inner%'
 `, schemaName)
 	if err != nil {
 		log.Println("schema", schemaName, err.Error())


### PR DESCRIPTION
Use system.xx instead of information_schema.xx , because the information_schema.key_column_usage is only supported at least in version 23.9