### PR TITLE
fix : mysql DescribeForeignKeysBySchema

### DIFF
--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -318,7 +318,7 @@ func (db *MySQLDBRepository) DescribeForeignKeysBySchema(ctx context.Context, sc
 				  on fks.CONSTRAINT_SCHEMA = kcu.TABLE_SCHEMA
 					  and fks.TABLE_NAME = kcu.TABLE_NAME
 					  and fks.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
-	where fks.CONSTRAINT_SCHEMA = ?
+	where fks.CONSTRAINT_SCHEMA = ? and  kcu.REFERENCED_COLUMN_NAME is not null
 	order by fks.CONSTRAINT_NAME,
 			 kcu.ORDINAL_POSITION
 		`, schemaName)


### PR DESCRIPTION
when some records have REFERENCED_COLUMN_NAME=null

fix for https://github.com/sqls-server/sqls/issues/172